### PR TITLE
Limits

### DIFF
--- a/deployment/croc-hunter-controller.template.yml
+++ b/deployment/croc-hunter-controller.template.yml
@@ -12,6 +12,13 @@ spec:
       containers:
       - name: croc-hunter
         image: quay.io/flywire/croc-hunter:${TPL_ENVIRONMENT:-release}-${WERCKER_GIT_COMMIT}
+        resources:
+          requests:
+            memory: "64M"
+            cpu: "300m"
+          limits:
+            memory: "128M"
+            cpu: "1"  
         ports:
         - containerPort: 8080
       imagePullSecrets:


### PR DESCRIPTION
Always is a good practice set limits for a container.

If you’re not sure how much resources to request, you can first launch the application without specifying resources, and use [resource usage monitoring](https://kubernetes.io/docs/user-guide/monitoring) to determine appropriate values.